### PR TITLE
typo in footer

### DIFF
--- a/static/jade/components/footer.jade
+++ b/static/jade/components/footer.jade
@@ -7,8 +7,7 @@ footer
       p.psf-trademark
         a(href='https://www.python.org/psf/trademarks/pycon/', target='_blank') PyCon™
         |  is a trademark for worldwide conference activities claimed by
-        a(href='https://www.python.org/psf-landing/', target='_blank')
-        Python Software Foundation
+        a(href='https://www.python.org/psf-landing/', target='_blank') Python Software Foundation
         | .
 
       p


### PR DESCRIPTION
There was typo in the footer - the word "Python" from PSF was eaten by jade processor. 

Hope, this fix will work.
