### PR TITLE
Sprints/Workshops content

### DIFF
--- a/static/data/workshops.json
+++ b/static/data/workshops.json
@@ -1,27 +1,6 @@
 [
   [
     {
-      "name": "Jachym Cepicky",
-      "avatar": "jachym_cepicky.jpg",
-      "title": "GIS in Python",
-      "abstract": "Python is one of the most popular programming languages, with strong support in nowadays GIS technologies. This workshop will give you overview of some basic libraries and their Python bindings (GDAL, Proj4), more abstract and easier to be used libraries (Rasterio, Fiona, Shapely), and show you, how to access GeoServer and Mapserver from Python script. OGC Standards and how to deal with them, will be demonstrated using OWSLib. Apparently, the topic is so wide, that at the end nobody is expected to master all or at least one of mentioned (or not mentioned) technologies. This workshop is meant as introduction to the world of GeoPython and brief overview.",
-      "bio": "Long time user and contributor to open source software for geospatial (GIS).",
-      "company": "GISMentors",
-      "twitter": "jachymc",
-      "github": "jachym"
-    },
-    {
-      "name": "Peter Inglesby",
-      "avatar": "peter_inglesby.jpg",
-      "title": "Django Security",
-      "abstract": "This workshop will explore some of the ways that Django helps you keep your applications and your users secure.\n\nWe'll do this by taking a simple Django site, disabling some of Django's built-in protections, and looking at how to exploit the weaknesses that become exposed.\n\nAlong the way, we'll look at types of attack including session hijacking, cross site scripting, cross site request forgery, and SQL injection.\n\nThis workshop is not a comprehensive \"HOW TO\" guide for keeping a Django site secure.\n\nInstead, its goal is to help you understand the mentality required to both evaluate the kinds of security risks that web applications are exposed to, and protect against those risks.",
-      "bio": "I'm a programmer and trainer from the UK.",
-      "company": "Import Training",
-      "twitter": "inglesp",
-      "github": "inglesp"
-    }
-  ], [
-    {
       "name": "Tomáš Bedřich",
       "avatar": "tobas_bedrich.png",
       "title": "Web scraping",
@@ -41,7 +20,18 @@
       "twitter": "",
       "github": ""
     }
-  ], [
+  ],
+  [
+    {
+      "name": "Jachym Cepicky",
+      "avatar": "jachym_cepicky.jpg",
+      "title": "GIS in Python",
+      "abstract": "Python is one of the most popular programming languages, with strong support in nowadays GIS technologies. This workshop will give you overview of some basic libraries and their Python bindings (GDAL, Proj4), more abstract and easier to be used libraries (Rasterio, Fiona, Shapely), and show you, how to access GeoServer and Mapserver from Python script. OGC Standards and how to deal with them, will be demonstrated using OWSLib. Apparently, the topic is so wide, that at the end nobody is expected to master all or at least one of mentioned (or not mentioned) technologies. This workshop is meant as introduction to the world of GeoPython and brief overview.",
+      "bio": "Long time user and contributor to open source software for geospatial (GIS).",
+      "company": "GISMentors",
+      "twitter": "jachymc",
+      "github": "jachym"
+    },
     {
       "name": "Nischal HP",
       "avatar": "nischal_hp.jpg",

--- a/static/jade/workshops/index.jade
+++ b/static/jade/workshops/index.jade
@@ -14,6 +14,8 @@ mixin talk(speaker)
       a.social.twitter(href="https://twitter.com/" + speaker.twitter)
         .fa.fa-twitter
 
+    p= speaker.abstract
+
   .commit-holder
     .commit
       img.avatar(src=avatar(speaker.avatar), alt='Photo of ' + speaker.name)
@@ -24,7 +26,8 @@ block vars
 block viewport
   .container
     h1 Sprints &amp; Workshops
-    
+
+    p.
     .event-full.general
       h2.title Breakfast
       .talk-description
@@ -33,22 +36,33 @@ block viewport
           Join us for delicous breakfast before coding madness begins      
       .commit.empty.first
         .dot
-    
+
     .branch
       img(
         src="/2015/static/images/ui/branch-in.svg",
         onerror="this.onerror = null; this.src = '/2015/static/images/ui/branch-in.png'"
       )
-    
-    //-  Iterate over workshops object (loaded in gulpfile from data/workshops.json)
-    //-  and render mixin talk() (see above)
-    each speaker, index in workshops
-      .talk-block
-        .event.master
-          +talk(speaker[0])
 
-        .event.practical
-          +talk(speaker[1])
+    .talk-block
+      .event.master
+        .talk-description
+          .speaker.
+            Sprints
+          p.
+           All day is open for you to sprint on any interesting project.
+
+        .commit-holder
+          .commit.empty
+
+      .event.practical
+        .talk-description
+          .speaker.
+            Workshops
+          p.
+            Get hands-on introduction to a project.
+
+        .commit-holder
+          .commit.empty
 
     .branch
       img(
@@ -66,6 +80,39 @@ block viewport
       
       .commit.empty.last
         .dot
+
+    h2 Sprints
+
+    p.
+        All day is open for you to sprint on any interesting project.
+        Sprints will be announced after lightning talks on Saturday.
+        If you want your sprint listed here before then, just e-mail the organizers.
+
+    h3 Python 3 Porting
+
+    p.
+        Make your project Python 3 compatible, or help a project you like!
+        Experienced porters can help you on your way, with guidance on porting
+        strategies, best practices, libraries and automation, or even
+        convincing management/upstream that supporting Python 3 is a good idea.
+
+    h2 Workshops
+    
+    Note that the workshops may still change.
+    
+    h3 Morning
+
+    each speaker, index in workshops[0]
+      .talk-block
+        .event.practical
+          +talk(speaker)
+
+    h3 Afternoon
+
+    each speaker, index in workshops[1]
+      .talk-block
+        .event.practical
+          +talk(speaker)
 
     a.anchor#directions
     h2 The venue


### PR DESCRIPTION
### Don't merge -- this is not styled.

Updated content for the Sprints & Workshops page.

I got lost in the visuals; I think it's best to leave those to a designer than me trying to wrap my head around them. But the content is here.

```
There are 4 tracks: sprints and 3 parallel workshops. This means
the "branch/commits" visual can't be used -- except for an overview
at the beginning (Sprints vs. Workshops).

Workshops are split into morning & afternoon.
We need to display the abstract. (Workshops will also have
requirements that attendees need installed; I'm currently collecting
these.)

The GIS workshop needs to be in the afternoon slot. Paul Inglesby's
workshop was cancelled.
```
